### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/Elements/emitter.cpp
+++ b/src/Elements/emitter.cpp
@@ -37,8 +37,12 @@ bool Emitter::addEmitter(Junction* junc, double c, double e, Pattern* p)
 {
     if ( junc->emitter == nullptr )
     {
-        junc->emitter = new Emitter();
-        if ( junc->emitter == nullptr ) return false;
+		try {
+			junc->emitter = new Emitter();
+		}
+		catch(std::bad_alloc& ba) {
+			return false;
+		}
     }
     junc->emitter->flowCoeff = c;
     junc->emitter->expon = e;

--- a/src/Elements/qualsource.cpp
+++ b/src/Elements/qualsource.cpp
@@ -37,8 +37,12 @@ bool QualSource::addSource(Node* node, int t, double b, Pattern* p)
 {
     if ( node->qualSource == nullptr )
     {
-        node->qualSource = new QualSource();
-        if ( node->qualSource == nullptr ) return false;
+		try {
+			node->qualSource = new QualSource();
+		}
+		catch (std::bad_alloc& ba) {
+			return false;
+		}
     }
     node->qualSource->type = t;
     node->qualSource->base = b;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'junc->emitter' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. emitter.cpp 41
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'node->qualSource' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. qualsource.cpp 41