### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/Utilities/mempool.cpp
+++ b/src/Utilities/mempool.cpp
@@ -30,19 +30,26 @@ struct MemBlock
 
 static struct MemBlock* createMemBlock()
 {
-    struct MemBlock* memBlock = new struct MemBlock;
-    if (memBlock)
-    {
-        memBlock->block = new char[ALLOC_BLOCK_SIZE];
-        if (memBlock->block == nullptr)
-        {
-            delete memBlock;
-            return nullptr;
-        }
-        memBlock->free = memBlock->block;
-        memBlock->next = nullptr;
-        memBlock->end = memBlock->block + ALLOC_BLOCK_SIZE;
-    }
+	struct MemBlock* memBlock;
+	
+	try {
+		memBlock = new struct MemBlock;
+
+		try {
+			memBlock->block = new char[ALLOC_BLOCK_SIZE];
+		}
+		catch (std::bad_alloc& ba) {
+			delete memBlock;
+			return nullptr;
+		}
+
+		memBlock->free = memBlock->block;
+		memBlock->next = nullptr;
+		memBlock->end = memBlock->block + ALLOC_BLOCK_SIZE;
+	}
+	catch (std::bad_alloc& ba) {
+	}
+
     return memBlock;
 }
 

--- a/src/Utilities/mempool.h
+++ b/src/Utilities/mempool.h
@@ -12,6 +12,7 @@
 #define MEMPOOL_H_
 
 #include <cstddef>
+#include <new> 
 
 struct MemBlock;
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'memBlock->block' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. mempool.cpp
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'memBlock' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. mempool.cpp