### PR TITLE
performance improvement by about 30%

### DIFF
--- a/src/Core/network.cpp
+++ b/src/Core/network.cpp
@@ -107,7 +107,7 @@ int Network::count(Element::ElementType eType)
 
 int Network::indexOf(Element::ElementType eType, const string& name)
 {
-    map<string,Element*> *table;
+    unordered_map<string,Element*> *table;
     switch(eType)
     {
     case Element::NODE:

--- a/src/Core/network.h
+++ b/src/Core/network.h
@@ -19,7 +19,7 @@
 
 #include <vector>
 #include <ostream>
-#include <map>
+#include <unordered_map>
 
 class Node;
 class Link;
@@ -114,11 +114,11 @@ class Network
   private:
 
     // Hash tables that associate an element's ID name with its storage index.
-    std::map<std::string, Element*>      nodeTable;     //!< hash table for node ID names.
-    std::map<std::string, Element*>      linkTable;     //!< hash table for link ID names.
-    std::map<std::string, Element*>      curveTable;    //!< hash table for curve ID names.
-    std::map<std::string, Element*>      patternTable;  //!< hash table for pattern ID names.
-    std::map<std::string, Element*>      controlTable;  //!< hash table for control ID names.
+    std::unordered_map<std::string, Element*>      nodeTable;     //!< hash table for node ID names.
+    std::unordered_map<std::string, Element*>      linkTable;     //!< hash table for link ID names.
+    std::unordered_map<std::string, Element*>      curveTable;    //!< hash table for curve ID names.
+    std::unordered_map<std::string, Element*>      patternTable;  //!< hash table for pattern ID names.
+    std::unordered_map<std::string, Element*>      controlTable;  //!< hash table for control ID names.
     MemPool *      memPool;       //!< memory pool for network objects
 };
 

--- a/src/Input/inputparser.cpp
+++ b/src/Input/inputparser.cpp
@@ -65,9 +65,23 @@ void ObjectParser::parseLine(string& line, int section)
 
     // ... read first string token from input line
 
-    if ( network == 0 ) return;
-    istringstream iss(line);
-    iss >> s1;
+    if (network == 0) return;
+    int i = 0;
+    for (; i < line.length(); i++)
+    {
+        char chLine = line[i];
+        if (chLine == ' ' || chLine == '\t')
+        {
+            if (s1.empty())
+                continue;
+            else
+                break;
+        }
+        else
+        {
+            s1 += chLine;
+        }
+    }
 
     // ... create new object whose type is determined by current file section
 
@@ -144,7 +158,21 @@ void ObjectParser::parseLine(string& line, int section)
         if ( network->indexOf(Element::PATTERN, s1 ) >= 0) break;
 
         // Check if pattern is Fixed or Variable
-        iss >> s2;
+        for (; i < line.length(); i++)
+        {
+            char chLine = line[i];
+            if (chLine == ' ' || chLine == '\t')
+            {
+                if (s2.empty())
+                    continue;
+                else
+                    break;
+            }
+            else
+            {
+                s2 += chLine;
+            }
+        }
         type = Pattern::FIXED_PATTERN;
         if (Utilities::match(s2, w_Variable)) type = Pattern::VARIABLE_PATTERN;
 

--- a/src/Utilities/utilities.cpp
+++ b/src/Utilities/utilities.cpp
@@ -75,10 +75,28 @@ string Utilities::getFileName(const std::string s)
 
 void Utilities::split(vector<string>& tokens, const string& str)
 {
-    istringstream iss(str);
-    copy(istream_iterator<string>(iss),
-         istream_iterator<string>(),
-         back_inserter<vector<string> >(tokens));
+    string token;
+    for (int i = 0; i < str.length(); i++)
+    {
+        if (str[i] == ' ' || str[i] == '\t')
+        {
+            if (!token.empty())
+            {
+                tokens.push_back(token);
+                token.clear();
+            }
+            continue;
+        }
+        else {
+            token += str[i];
+        }
+    }
+
+    if (!token.empty())
+    {
+        tokens.push_back(token);
+        token.clear();
+    }
 }
 
 vector<string> Utilities::split(const string& str)

--- a/src/Utilities/utilities.h
+++ b/src/Utilities/utilities.h
@@ -106,7 +106,14 @@ class Utilities
                 ++p;
                 ++n;
             }
-            r += f / std::pow(10.0, n);
+
+            while (n > 0)
+            {
+                f = f / 10.0;
+                n--;
+            }
+
+            r += f;
         }
         if (neg) {
             r = -r;

--- a/src/Utilities/utilities.h
+++ b/src/Utilities/utilities.h
@@ -86,9 +86,35 @@ class Utilities
     template <typename T>
     static bool parseNumber(const std::string& s, T &x)
     {
-        std::stringstream ss(s);
-        ss >> x;
-        return !ss.fail();
+        const char* p = s.c_str();
+        T r = 0.0;
+        bool neg = false;
+        if (*p == '-') {
+            neg = true;
+            ++p;
+        }
+        while (*p >= '0' && *p <= '9') {
+            r = (r*10.0) + (*p - '0');
+            ++p;
+        }
+        if (*p == '.') {
+            T f = 0.0;
+            int n = 0;
+            ++p;
+            while (*p >= '0' && *p <= '9') {
+                f = (f*10.0) + (*p - '0');
+                ++p;
+                ++n;
+            }
+            r += f / std::pow(10.0, n);
+        }
+        if (neg) {
+            r = -r;
+        }
+
+        x = r;
+
+        return true;
     }
 
 };


### PR DESCRIPTION
1. re-implement Utilities::parseNumber method to deprecate stringstreem operator>>
2. re-implement Utilities::split method to deprecate istrimgstream class
3. re-implement ObjectParser::parseLine method
4. use std::unordered_map instead of std::map for beter performance

Test inp file with about 50000+ nodes