### PR TITLE
fix - epanet 3 can't run epanet 2 INP file when set Quality option to "TRACE" and specify a TRACE node

### DIFF
--- a/src/Core/options.cpp
+++ b/src/Core/options.cpp
@@ -211,6 +211,10 @@ int Options::setOption(StringOption option, const string& value)
         if ( i == MGL || i == UGL ) indexOptions[QUAL_UNITS] = i;
         break;
 
+    case TRACE_NODE_NAME:
+        stringOptions[TRACE_NODE_NAME] = value;
+        break;
+
     default: break;
     }
     return 0;

--- a/src/Input/optionparser.cpp
+++ b/src/Input/optionparser.cpp
@@ -67,7 +67,7 @@ static const char* epanet2Keywords[] =
      "PATTERN", "DEMAND", "EMITTER","TOLERANCE", "MAP", 0};
 
 static const char* epanetQualKeywords[] =
-    {"NONE", "CHEMICAL", "AGE", "TRACE", 0};
+    {"NONE", "AGE", "TRACE", "CHEMICAL", 0};
 
 //-----------------------------------------------------------------------------
 
@@ -475,6 +475,9 @@ void OptionParser::parseQualOption(const string& s2, const string& s3,
     {
         if ( network->option(Options::QUAL_TYPE) == Options::TRACE )
         {
+            int nodeIndex = network->indexOf(Element::NODE, s3);
+            if (i < 0) throw InputError(InputError::UNDEFINED_OBJECT, s3);
+            network->options.setOption(Options::TRACE_NODE, nodeIndex);
             network->options.setOption(Options::TRACE_NODE_NAME, s3);
         }
         if ( network->option(Options::QUAL_TYPE) == Options::CHEM )


### PR DESCRIPTION
**epanet 2 INP file is not compatible with epanet 3 when set Quality option to "TRACE" and specify a TRACE node**

## Reproduce Steps
1. Launch EPANET GUI 2.00.12.1, open the sample Net1.net file
2. Go to the "Quality" Option editor, change the "Parameter" property to "Trace", specify the "Trace Node" to "9" (The reservoir 9 in the network).
3. Export the network as "Net1.inp" file
4. run `run-epanet3.exe {fileDirectory}\Net1.inp {fileDirectory}\Net1.rpt`
5. The simulation process fails. And the Net1.rpt file says:
```
*** INPUT ERROR 203: invalid keyword 9 at following line of [OPTION] section:
 Quality            	Trace 9
*** INPUT ERROR 200: one or more errors in network input data.
```

## Analysis & Solution
1. The enum order and text order of Quality parameter are not same, which causes the `Options::QUAL_TYPE` option to be set a wrong type (*Options::CHEM*) when open Net1.inp file. 
  * The text order: 
    [epanetQualKeywords](https://github.com/OpenWaterAnalytics/epanet-dev/blob/5898d9b935468ab46ebd2f8fd581e318457b92bd/src/Input/optionparser.cpp#L69)
```
    static const char* epanetQualKeywords[] =
        {"NONE", "CHEMICAL", "AGE", "TRACE", 0};
```
  * The enum order: 
    [enum QualType      {NOQUAL, AGE, TRACE, CHEM};](https://github.com/OpenWaterAnalytics/epanet-dev/blob/5898d9b935468ab46ebd2f8fd581e318457b92bd/src/Core/options.h#L34)
```
    enum QualType      {NOQUAL, AGE, TRACE, CHEM};
```

So that, the error will happen when try to parse a TRACE mode to be a CHEM mode.  
```
*** INPUT ERROR 203: invalid keyword 9 at following line of [OPTION] section:
 Quality            	Trace 9
```

2. To fix the above issue, we need to keep the text and enum order of Quality parameter to be same.
After synchronize the text and enum orders, there is another issue, the trace node has not been set, and it will cause crash later when try to visit the Trace node.
Crash point: [traceNode = nw->node(nw->option(Options::TRACE_NODE));](https://github.com/OpenWaterAnalytics/epanet-dev/blob/5898d9b935468ab46ebd2f8fd581e318457b92bd/src/Models/qualmodel.cpp#L272) in:
```
    void TraceModel::init(Network* nw)
    {
        traceNode = nw->node(nw->option(Options::TRACE_NODE));
        traceNode->quality = Ctrace;
    }
```

The original setOption method is [int Options::setOption(StringOption option, const string& value)](https://github.com/OpenWaterAnalytics/epanet-dev/blob/5898d9b935468ab46ebd2f8fd581e318457b92bd/src/Core/options.cpp#L154), which didn't handle the case **Options::TRACE_NODE_NAME**.
So, to fix the issue, we need to set the Trace Node index and Name to corresponding options.
