### PR TITLE
Fix a regression to accept numbers in scientific notation from INP file

### DIFF
--- a/src/Utilities/utilities.h
+++ b/src/Utilities/utilities.h
@@ -121,7 +121,13 @@ class Utilities
 
         x = r;
 
-        return true;
+        if (*p == '\0')
+            return true;
+
+        // for some numbers in scientific notation 
+        std::stringstream ss(s);
+        ss >> x;
+        return !ss.fail();
     }
 
 };


### PR DESCRIPTION
In PR #39, I did some refactors for better performance, including re-implement the method by a hand-written naive loop, which brought in about dozens times performance improvement to load an INP file:
```
    static bool Utilities::parseNumber(const std::string& s, T &x)
``` 

But, there was a regression introduced, the naive loop can't accept number in scientific notation. 

This PR is to fix the regression to have a balance for performance and correctness: 
*  at first, we will try to parse the number by naive loop,
*  if fail, then try to use `std::stringstream` to do parse again. 
