### PR TITLE
fix - for VSP with custom curve, the headloss calculation is not correct

### DIFF
--- a/src/Elements/pumpcurve.cpp
+++ b/src/Elements/pumpcurve.cpp
@@ -257,7 +257,7 @@ void PumpCurve::customCurveHeadLoss(
 
     // ... find slope and intercept of curve segment
 
-    curve->findSegment(q, r, h0);
+    curve->findSegment(q / speed, r, h0);
 
     // ... adjust slope and intercept for pump speed
 


### PR DESCRIPTION
For a pump with custom curve, the speed should be taken into consideration to calculate the intercept of the curve.

Test INP file [PumpCurveTest.zip](https://github.com/OpenWaterAnalytics/epanet-dev/files/4590378/PumpCurveTest.zip)

