### PR TITLE
adjusts status of links controlled by junction pressures after a hydraulic solution is found

### DIFF
--- a/src/Elements/control.cpp
+++ b/src/Elements/control.cpp
@@ -117,9 +117,10 @@ int Control::timeToActivate(Network* network, int t, int tod)
 
 //-----------------------------------------------------------------------------
 
-void Control::applyPressureControls(Network* network)
+bool Control::applyPressureControls(Network* network)
 {
     bool makeChange = true;
+    bool changed = false;
 
     for (Control* control : network->controls)
     {
@@ -130,10 +131,13 @@ void Control::applyPressureControls(Network* network)
             ||   (control->levelType == HI_LEVEL &&
                   control->node->head > control->head) )
             {
-                control->activate(makeChange, network->msgLog);
+                if (control->activate(makeChange, network->msgLog))
+                    changed = true;
             }
         }
     }
+
+    return changed;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Elements/control.h
+++ b/src/Elements/control.h
@@ -36,8 +36,9 @@ class Control: public Element
     Control(int type_, std::string name_);
     ~Control();
 
-    // Applies all pressure controls to the pipe network
-    static  void     applyPressureControls(Network* network);
+    // Applies all pressure controls to the pipe network,
+    // return true if status of any link changes
+    static  bool     applyPressureControls(Network* network);
 
     // Sets the properties of a control
     void    setProperties(

--- a/src/Solvers/ggasolver.cpp
+++ b/src/Solvers/ggasolver.cpp
@@ -17,6 +17,7 @@
 #include "matrixsolver.h"
 #include "Core/network.h"
 #include "Core/constants.h"
+#include "Elements/control.h"
 #include "Elements/junction.h"
 #include "Elements/tank.h"
 #include "Elements/link.h"
@@ -659,7 +660,8 @@ bool GGASolver::linksChangedStatus()
 	//if ( result && reportTrials ) network->msgLog << endl;
 
     // --- look for status changes caused by pressure switch controls
-    ////////  TO BE ADDED  ////////
-    //changeCount += control_ApplyPressureControls();
+    if (Control::applyPressureControls(network))
+        result = true;
+
     return result;
 }


### PR DESCRIPTION
two changes in this commit:

1. add the return type as boolean for method Control::applyPressureControls(Network* network) to return true if status of any link changes
2. apply the pressure controls after a hydraulic solution is found (the GGASolver has converged)