### PR TITLE
 fix - LinkStatus of VSP doesn't change after setting new speed to previous speed before closed status

### DIFF
--- a/src/Elements/pump.cpp
+++ b/src/Elements/pump.cpp
@@ -109,7 +109,11 @@ bool Pump::changeStatus(int s, bool makeChange, const string reason, ostream& ms
         if ( makeChange )
         {
             if ( s == LINK_OPEN && speed == 0.0 ) speed = 1.0;
-            if ( s == LINK_CLOSED ) flow = ZERO_FLOW;
+            if ( s == LINK_CLOSED )
+            {
+                flow = ZERO_FLOW;
+                speed = 0.0;
+            }
             msgLog << "\n    " << reason;
             status = s;
         }


### PR DESCRIPTION
The LinkStatus of VSP doesn't change after setting new speed to previous speed before closed status

Reproduce steps:
1. PUMP_A is a VSP
2. Add Control as below: 
```
LINK PUMP_A  0.9 AT TIME 1:00
LINK PUMP_A  CLOSED  AT TIME 2:00
LINK PUMP_A  0.9 AT TIME 3:00
```
3. After running simulation, the PUMP_A is still closed.

Solution:
When VSP status is set to LINK_CLOSED, the speed should be reset to 0.