### PR TITLE
fix the time convertor that format is HH:mm:ss with AM/PM

### DIFF
--- a/src/Utilities/utilities.cpp
+++ b/src/Utilities/utilities.cpp
@@ -200,6 +200,25 @@ int Utilities::getSeconds(const string& strTime, const string& strUnits)
     {
         int h = 0, m = 0, s = 0;
         if (sscanf(strTime.c_str(), "%d:%d:%d", &h, &m, &s) == 0) return -1;
+
+        if (strUnits.size() > 0)
+        {
+            if (match(strUnits, s_AM))
+            {
+                if (h >= 13) return -1;
+                if (h == 12) h -= 12;
+            }
+            else if (match(strUnits, s_PM))
+            {
+                if (h >= 13) return -1;
+                if (h < 12)  h += 12;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+
         return 3600*h + 60*m + s;
     }
 


### PR DESCRIPTION
### Problem:

`Utilities::getSeconds` method converts a time value into seconds. If the time format is *HH:mm:ss*, it doesn't consider the postfix **AM/PM**. As a result, for some controls, variable patterns, and time options which use the *HH:mm::ss* time format with **PM**, the time will be treated as **AM** by default.
Samples:
```
LINK 12 OPEN AT CLOCKTIME 6:00 AM 
LINK 12 CLOSED AT CLOCKTIME 8:00 PM 
```
The control expects the behavior: open the link at 6:00 in the morning, and close it at 20:00 in the evening. But now, it will be closed in 8:00 in the morning.

### Fix:
Take the **AM/PM** into consideration in `Utilities::getSeconds` method for time format *HH:mm:ss* too.