### PR TITLE
fix a typo in Curve::getYofX(double x) method

### DIFF
--- a/src/Elements/curve.cpp
+++ b/src/Elements/curve.cpp
@@ -71,7 +71,7 @@ double Curve::getYofX(double x)
         {
             double dx = xData[i] - xData[i-1];
             if ( dx == 0.0 ) return yData[i-1];
-            return yData[i-1] + (x - yData[i-1]) / dx * (yData[i] - yData[i-1]);
+            return yData[i-1] + (x - xData[i-1]) / dx * (yData[i] - yData[i-1]);
         }
     }
     return yData[xData.size()-1];


### PR DESCRIPTION
There is a typo in Curve::getYofX method
return yData[i-1] + (x - **yData**[i-1]) / dx * (yData[i] - yData[i-1]);
the second `yData[i-1]` should be `xData[i-1]`

After the fix, the runtime Efficiency/Flow relationship graph will align with the Efficiency Curve: 
![image](https://user-images.githubusercontent.com/34054635/86119586-58f67980-bb05-11ea-82e4-511a666aa3b1.png)
