### PR TITLE
fix a time parse issue (with units) in Utilities::getSeconds method

### DIFF
--- a/src/Utilities/utilities.cpp
+++ b/src/Utilities/utilities.cpp
@@ -233,10 +233,10 @@ int Utilities::getSeconds(const string& strTime, const string& strUnits)
 
     // determine time units and convert time accordingly
 
-    if (match(strUnits, s_Day) == 0)    return (int) (3600. * 24. * t);
-    if (match(strUnits, s_Hour) == 0)   return (int) (3600. * t);
-    if (match(strUnits, s_Minute) == 0) return (int) (60. * t);
-    if (match(strUnits, s_Second) == 0) return (int) t;
+    if (match(strUnits, s_Day))    return (int) (3600. * 24. * t);
+    if (match(strUnits, s_Hour))   return (int) (3600. * t);
+    if (match(strUnits, s_Minute)) return (int) (60. * t);
+    if (match(strUnits, s_Second)) return (int) t;
 
     // if AM/PM supplied, time is in hours and adjust it accordingly
 


### PR DESCRIPTION
in `Utilities::getSeconds` method, it uses `match` method to determine the time units
the `bool Utilities::match(const string& s1, const string& s2)` method returns a boolean value.
the conditional check between a boolean value and int value (0) is not appropriate. It may return unexpected result.

e.g. set Start Simulation Time as 4 AM, INP file looks like 
`Start ClockTime        4 AM`
The `match` method returns false, and then the conditional `if (false == 0)`  will get true, and return the seconds as 3600 * 24 * 4 on the code line
`if (match(strUnits, s_Day) == 0)    return (int) (3600. * 24. * t);`

Fix:
Determine the `match` method in `if` statement since it returns a boolean value