### PR TITLE
fix several units conversion issues for quality simulation

### DIFF
--- a/src/Input/linkparser.cpp
+++ b/src/Input/linkparser.cpp
@@ -201,10 +201,10 @@ void LinkParser::parseReaction(Link* link, int type, vector<string>& tokenList)
         throw InputError(InputError::INVALID_NUMBER, tokens[1]);
     }
 
-    // ... save reaction coeff. converted to 1/sec
+    // ... save reaction coeff.
 
-    if      (type == Link::BULK) pipe->bulkCoeff = x / SECperDAY;
-    else if (type == Link::WALL) pipe->wallCoeff = x / SECperDAY;
+    if      (type == Link::BULK) pipe->bulkCoeff = x;
+    else if (type == Link::WALL) pipe->wallCoeff = x;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Input/nodeparser.cpp
+++ b/src/Input/nodeparser.cpp
@@ -224,7 +224,7 @@ void NodeParser::parseTankReact(Node* node, vector<string>& tokenList)
 
     // ... read reaction coefficient in 1/days
 
-    if ( !Utilities::parseNumber(tokens[1], tank->bulkCoeff) )
+    if ( !Utilities::parseNumber(tokens[2], tank->bulkCoeff) )
     {
         throw InputError(InputError::INVALID_NUMBER, tokens[1]);
     }

--- a/src/Input/nodeparser.cpp
+++ b/src/Input/nodeparser.cpp
@@ -228,10 +228,6 @@ void NodeParser::parseTankReact(Node* node, vector<string>& tokenList)
     {
         throw InputError(InputError::INVALID_NUMBER, tokens[1]);
     }
-
-    // ... convert coefficient to 1/sec
-
-    tank->bulkCoeff /= 86400;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Input/nodeparser.cpp
+++ b/src/Input/nodeparser.cpp
@@ -226,7 +226,7 @@ void NodeParser::parseTankReact(Node* node, vector<string>& tokenList)
 
     if ( !Utilities::parseNumber(tokens[2], tank->bulkCoeff) )
     {
-        throw InputError(InputError::INVALID_NUMBER, tokens[1]);
+        throw InputError(InputError::INVALID_NUMBER, tokens[2]);
     }
 }
 

--- a/src/Models/qualmodel.cpp
+++ b/src/Models/qualmodel.cpp
@@ -60,6 +60,7 @@ ChemModel::ChemModel() : QualModel(CHEM)
     wallOrder = 1.0;        // pipe wall reaction order
     pipeUcf = 1.0;          // volume conversion factor for pipes
     tankUcf = 1.0;          // volume conversion factor for tanks
+    radiusUcf = 1.0;        // hydraulic radius conversion factor for pipes
     cLimit = 0.001;         // min/max concentration limit (mass/ft3)
 }
 
@@ -79,6 +80,8 @@ void ChemModel::init(Network* nw)
     // volume conversion factors for reaction rate expressions
     pipeUcf = pow(LperFT3, (1.0 - pipeOrder));
     tankUcf = pow(LperFT3, (1.0 - tankOrder));
+
+    radiusUcf = nw->ucf(Units::LENGTH);
 
     // save diffusuivity, viscosity & Schmidt number
     diffus = nw->option(Options::MOLEC_DIFFUSIVITY);
@@ -236,7 +239,7 @@ double ChemModel::findWallRate(double kw, double d, double order, double c)
     if ( massTransCoeff == 0.0 )
     {
         if (order == 0.0) c = 1.0;
-        return c * kw / rh;
+        return c * kw / rh / radiusUcf;
     }
 
     // ... otherwise rate is combination of wall & mass transfer coeff.
@@ -257,6 +260,7 @@ double ChemModel::findWallRate(double kw, double d, double order, double c)
         else
         {
             double kf = massTransCoeff;
+            kw /= radiusUcf;
             return c * kw * kf / (kf + abs(kw)) / rh;
         }
     }

--- a/src/Models/qualmodel.h
+++ b/src/Models/qualmodel.h
@@ -88,6 +88,7 @@ class ChemModel : public QualModel
     double  massTransCoeff;   // a pipe's mass transfer coeff. (ft/sec)
     double  pipeUcf;          // volume conversion factor for pipes
     double  tankUcf;          // volume conversion factor for tanks
+    double  radiusUcf;        // hydraulic radius conversion factor for pipes
     double  cLimit;           // min/max concentration limit (mass/ft3)
 
     bool    setReactive(Network* nw);

--- a/src/Models/qualmodel.h
+++ b/src/Models/qualmodel.h
@@ -88,7 +88,7 @@ class ChemModel : public QualModel
     double  massTransCoeff;   // a pipe's mass transfer coeff. (ft/sec)
     double  pipeUcf;          // volume conversion factor for pipes
     double  tankUcf;          // volume conversion factor for tanks
-    double  radiusUcf;        // hydraulic radius conversion factor for pipes
+    double  wallUcf;          // wall reaction coefficient conversion factor for pipes
     double  cLimit;           // min/max concentration limit (mass/ft3)
 
     bool    setReactive(Network* nw);


### PR DESCRIPTION
There are several units conversion issues for quality simulation:

## Issue 1
### Description & Analysis
The time units of both the global and pipe/tank's reaction coefficients (Bulk/Wall) defined in INP file are 1/days.
During node/pipe data parsing, the reaction coefficients' time units are converted to 1/seconds. But the global time units still keep 1/days.

Actually in the water quality solver, the time units will be converted to 1/seconds when updating chemical's pipe/tank concentration after reaction. see [`double ChemModel::pipeReact(Pipe* pipe, double c, double tstep)` ](https://github.com/OpenWaterAnalytics/epanet-dev/blob/b9a4df3dd56b7c976ddd0c7a0b88d18fdb9f0994/src/Models/qualmodel.cpp#L159) and [`double ChemModel::tankReact(Tank* tank, double c, double tstep)`](https://github.com/OpenWaterAnalytics/epanet-dev/blob/develop/src/Models/qualmodel.cpp#L177).

As a result, the pipe/tank's reaction coefficients have been converted to 1/seconds twice (divided by 86400 * 86400) if the pipe/tank has override the global reaction coefficients by editing the properties.

### Solution:
During node/pipe data parsing, the reaction coefficients' time units keep 1/days same as the global reaction coefficients.

## Issue 2
### Analysis
~~During finding wall reaction rate, the hydraulic radius unit conversion has not been taken in consideration, see method [`ChemModel::findWallRate`](https://github.com/OpenWaterAnalytics/epanet-dev/blob/develop/src/Models/qualmodel.cpp#L227)~~

### Solution
~~Add a unit conversion for hydraulic radius, which is equal to the factor of `Units::LENGTH`, which will be used when calculating the wall reaction rate.~~

As @LRossman 's correction, the hydraulic radius doesn't need to be converted because it already has the internal units of feet, however the pipe wall coefficient does need conversion because it has metric units of m/day for 1st order wall reactions or mass/m2/day for 0-order reactions. See more details in @LRossman 's comment.
[updated by @WaterDesk 9/19/2021]

## Issue 3
During parsing tank reaction coefficient from INP file, the index of reaction coeff. number in the tokens should be 2, but not 1.