### PR TITLE
fix - OptionParser::parseQualOption doesn't consider the cases for "Quality Trace" mode: the trace node has not been specified; the specified trace node doesn't exist

### DIFF
--- a/src/Input/optionparser.cpp
+++ b/src/Input/optionparser.cpp
@@ -471,25 +471,25 @@ void OptionParser::parseQualOption(const string& s2, const string& s3,
         network->options.setOption(Options::QUAL_UNITS, Options::MGL);
     }
 
-    if ( !s3.empty() )
+    if (network->option(Options::QUAL_TYPE) == Options::TRACE)
     {
-        if ( network->option(Options::QUAL_TYPE) == Options::TRACE )
-        {
-            int nodeIndex = network->indexOf(Element::NODE, s3);
-            if (i < 0) throw InputError(InputError::UNDEFINED_OBJECT, s3);
-            network->options.setOption(Options::TRACE_NODE, nodeIndex);
-            network->options.setOption(Options::TRACE_NODE_NAME, s3);
-        }
-        if ( network->option(Options::QUAL_TYPE) == Options::CHEM )
-        {
-            string s3U = Utilities::upperCase(s3);
-            if ( s3U.compare("MG/L") == 0 )
-                network->options.setOption(Options::QUAL_UNITS, Options::MGL);
-            else if ( s3U.compare("UG/L") == 0 )
-                network->options.setOption(Options::QUAL_UNITS, Options::UGL);
-            else throw InputError(InputError::INVALID_KEYWORD, s3);
-        }
-     }
+        if (s3.empty()) throw InputError(InputError::UNDEFINED_OBJECT, s3);
+        int nodeIndex = network->indexOf(Element::NODE, s3);
+        if (nodeIndex < 0) throw InputError(InputError::UNDEFINED_OBJECT, s3);
+        network->options.setOption(Options::TRACE_NODE, nodeIndex);
+        network->options.setOption(Options::TRACE_NODE_NAME, s3);
+    }
+
+    if (network->option(Options::QUAL_TYPE) == Options::CHEM)
+    {
+        if (s3.empty()) throw InputError(InputError::INVALID_KEYWORD, s3);
+        string s3U = Utilities::upperCase(s3);
+        if (s3U.compare("MG/L") == 0)
+            network->options.setOption(Options::QUAL_UNITS, Options::MGL);
+        else if (s3U.compare("UG/L") == 0)
+            network->options.setOption(Options::QUAL_UNITS, Options::UGL);
+        else throw InputError(InputError::INVALID_KEYWORD, s3);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Input/optionparser.cpp
+++ b/src/Input/optionparser.cpp
@@ -480,9 +480,8 @@ void OptionParser::parseQualOption(const string& s2, const string& s3,
         network->options.setOption(Options::TRACE_NODE_NAME, s3);
     }
 
-    if (network->option(Options::QUAL_TYPE) == Options::CHEM)
+    if (network->option(Options::QUAL_TYPE) == Options::CHEM && !s3.empty())
     {
-        if (s3.empty()) throw InputError(InputError::INVALID_KEYWORD, s3);
         string s3U = Utilities::upperCase(s3);
         if (s3U.compare("MG/L") == 0)
             network->options.setOption(Options::QUAL_UNITS, Options::MGL);


### PR DESCRIPTION
**Issue Description:** 
if the model is set to Quality Trace mode, but the traced node has not been specified or specified to a wrong node ID. 
the application will crash during initializing the TraceModel since the trace node index is -1.
```
void TraceModel::init(Network* nw)
{
    traceNode = nw->node(nw->option(Options::TRACE_NODE));
    traceNode->quality = Ctrace;
}
```

**Analysis and Solution:**
In OptionParser::parseQualOption method, the validation of "traced node" has not been done correctly in "Quality Trace" node.
1. if the traced node is not specified, we should throw InputError exception with type "UNDEFINED_OBJECT"
2. there is a typo to check if the specified traced node is invalid or can't be found. We should use `nodeIndex` but not `i`

<del>Btw, the "Quality Chemical" mode should check the third parameter similar as "Quality Trace" mode too.  </del>
**update:** The third token is optional for CHEM quality type as @LRossman said. So, in this code change, only TRACE mode will be impacted.