### PR TITLE
fix - the last volume segment should be initialized as the first volume segment during intializing a tank's mixing model

### DIFF
--- a/src/Models/tankmixmodel.cpp
+++ b/src/Models/tankmixmodel.cpp
@@ -46,10 +46,10 @@ void TankMixModel::init(Tank* tank, SegPool* segPool, double _cTol)
     vMixed = fracMixed * tank->maxVolume;
 
     // ... create a volume segment for the entire tank
-    lastSeg = nullptr;
     firstSeg = segPool->getSegment(tank->volume, cTank);
     if ( firstSeg == nullptr )
         throw SystemError(SystemError::OUT_OF_MEMORY);
+    lastSeg = firstSeg;
 
     // ... create a second segment for the 2-compartment model
     if ( type == MIX2 )


### PR DESCRIPTION
**Issue Description:** 
Run simulation (age mode) for the test file _tank_FIFO.inp_, the simulation will be stuck in a loop (`TankMixModel::findFIFOQuality`). There is a tank object in the model, and sometimes the flow will be 0 controlled by controls.

**Analysis & Solution:**
During initializing the tank's mixing model, the last volume segment has not been initialized (default as nullptr). 
Then in `TankMixModel::findFIFOQuality` method, it adds a new last segment to the tank, but now there is no relationship between the first segment and last segment (firstSeg->next (or ...->next will never point to lastSeg). firstSeg->next is always nullptr.

```
//  Find the quality leaving the the first segment of a plug flow (FIFO) tank.

double TankMixModel::findFIFOQuality(double vNet, double vIn, double wIn,
                                     SegPool* segPool)
{
    ...
    while (vOut > 0.0)
    {
        Segment* seg = firstSeg;
        if ( seg == nullptr ) break;    // never reach here to break
        double vSeg = min(seg->v, vOut);   // if seg->v is 0, infinite loop
        if ( seg == lastSeg ) vSeg = vOut;   // never reach here to change vSeg as vOut
        vSum += vSeg;
        wSum += seg->c * vSeg;
        vOut -= vSeg;
        if ( vOut >= 0.0 && vSeg >= seg->v && seg->next )
        {
            firstSeg = seg->next;     // will never reach here since firstSeg->next is null 
            segPool->freeSegment(seg);
        }
        else seg->v -= vSeg;
    }
    ...
```
As above code, the variable `seg` is initialized as `firstSeg`, and `seg` will never point to lastSeg. So in that case, if the firstSeg->v is 0, the loop is infinite.

**Solution:**
Initialize the last volume segment as the first volume segment, do as EPANET 2.0 did.

**Test File**
[tank_FIFO.zip](https://github.com/OpenWaterAnalytics/epanet-dev/files/10203989/tank_FIFO.zip)
