### PR TITLE
fix several quality source issues

### DIFF
--- a/src/Elements/junction.cpp
+++ b/src/Elements/junction.cpp
@@ -7,6 +7,7 @@
 
 #include "junction.h"
 #include "emitter.h"
+#include "qualsource.h"
 #include "Core/network.h"
 #include "Core/constants.h"
 #include "Models/demandmodel.h"
@@ -82,6 +83,7 @@ void Junction::initialize(Network* nw)
 {
     head = elev + (pFull - pMin) / 2.0;;
     quality = initQual;
+    if (qualSource) qualSource->quality = quality;
     actualDemand = 0.0;
     outflow = 0.0;
     fixedGrade = false;

--- a/src/Elements/qualsource.cpp
+++ b/src/Elements/qualsource.cpp
@@ -54,7 +54,7 @@ void QualSource::setStrength(Node* node)
 {
     strength = base;
     if ( pattern ) strength *= pattern->currentFactor();
-    if ( type == MASS ) strength *= 60.0;         // mass/min -> mass/sec
+    if ( type == MASS ) strength /= 60.0;         // mass/min -> mass/sec
     else                strength /= FT3perL;      // mass/L -> mass/ft3
 }
 
@@ -64,7 +64,15 @@ double QualSource::getQuality(Node* node)
 {
     // ... no source contribution if no flow out of node
     quality = node->quality;
-    if ( outflow == 0.0 ) return quality;
+    if (abs(outflow) <= ZERO_FLOW)
+    {
+        if (node->type() == Node::JUNCTION && node->outflow < 0.0)
+        {
+            if (type == MASS) quality = strength * 60.0;    // mass/sec -> mass/min
+            else              quality = strength;
+        }
+        return quality;
+    }
 
     switch (type)
     {

--- a/src/Elements/tank.cpp
+++ b/src/Elements/tank.cpp
@@ -7,6 +7,7 @@
 
 #include "tank.h"
 #include "curve.h"
+#include "qualsource.h"
 #include "Core/network.h"
 #include "Core/constants.h"
 #include "Core/error.h"
@@ -107,6 +108,7 @@ void Tank::initialize(Network* nw)
     outflow = 0.0;
     pastOutflow = 0.0;
     quality = initQual;
+    if (qualSource) qualSource->quality = quality;
     updateArea();
     if ( volCurve ) minVolume = findVolume(minHead);
     else if ( minVolume == 0.0 ) minVolume = (minHead - elev) * area;

--- a/src/Solvers/ltdsolver.cpp
+++ b/src/Solvers/ltdsolver.cpp
@@ -308,7 +308,7 @@ void LTDSolver::updateNodeQuality()
             if ( node->type() == Node::JUNCTION )
             {
                 // ... account for dilution from any external negative demand
-                if (node->outflow < 0.0 && node->qualSource == nullptr )
+                if (node->outflow < 0.0 && node->qualSource != nullptr )
                 {
                     volIn[i] -= node->outflow * tstep;
                 }


### PR DESCRIPTION
fix several quality source issues:

1. the junction and tank's source quality has not been initialized
2. for MASS Booster quality source type, converting mass flow rate from min. to sec. uses strength *= 60.0, which should be strength /= 60.0
3. in QualSource::getQuality method, to determine if there is no flow out of node, now it uses "==0.0", which should use ZERO_FLOW as instead
4. no source contribution if no flow out of node, but for inflow junction, the source contribution should be the source quality
5. the inflow junction's constituent concentration has not been updated if the junction has Quality Source in LTDSolver::updateNodeQuality method