### PR TITLE
reset valve setting when valve status changes to be a fixed status (OPEN/CLOSED) by controls

### DIFF
--- a/src/Elements/valve.cpp
+++ b/src/Elements/valve.cpp
@@ -462,6 +462,7 @@ bool Valve::changeStatus(
             msgLog << "\n    " << reason;
             status = newStatus;
             hasFixedStatus = true;
+            setting = 0.0; // reset setting when status is fixed
             if ( status == LINK_CLOSED ) flow = ZERO_FLOW;
         }
         return true;


### PR DESCRIPTION
## Issue Summary
In EPANET's control system, there's a bug when sequencing valve controls in the following pattern:

1. Set valve to a specific numeric setting
2. Set valve to OPEN/CLOSED
3. Set valve back to the original numeric setting

In this case, the third control command (returning to the original numeric setting) is not properly executed.

## Detailed Description
### Problem Scenario
When implementing valve controls with this sequence:
```
LINK VALVE_1 56 AT TIME 0:00
LINK VALVE_1 CLOSED AT TIME 1:00
LINK VALVE_1 56 AT TIME 2:00
```

The third control command (setting back to 56 at 2:00) fails to take effect.

### Expected Behavior
All three control commands should be executed in sequence:

1. Valve should be set to setting 56 at 0:00
2. Valve should be fully closed at 1:00
3. Valve should return to setting 56 at 2:00

### Actual Behavior
Only the first two controls are executed:

1. Valve is set to 56 at 0:00
2. Valve is closed at 1:00
3. The command to return to 56 at 2:00 is **ignored**

## Solution
When change the valve status to a fixed status (OPEN/CLOSED), the `setting` value should be reset to be 0.0.